### PR TITLE
Add status reports page aa1 to implement aa1

### DIFF
--- a/tastic/urls.py
+++ b/tastic/urls.py
@@ -11,5 +11,5 @@ urlpatterns = [
     path("features/", views.features, name="features_route"),
     path("dods/", views.dods, name="dods_route"),
     path("stories/", views.stories, name="user_stories_route"),
-    path("reports/", views.index, name="status_reports_route"),
+    path("reports/", views.reports, name="status_reports_route"),
 ]

--- a/tastic/views.py
+++ b/tastic/views.py
@@ -242,3 +242,102 @@ def stories(request):
 
     # Render site
     return render(request, "pages/stories.html", values)
+
+
+def reports(request):
+    # Dummy Data
+    values = {
+        "sortedBy": "Newest",
+        "users": [
+            {
+                "name": "Pinterid",
+                "is_authenticated": True,
+                "files": [
+                    {
+                        "name": "File1",
+                        "createdAt": "29/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                    {
+                        "name": "File2",
+                        "createdAt": "30/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                ],
+            },
+            {
+                "name": "Kleber",
+                "is_authenticated": False,
+                "files": [
+                    {
+                        "name": "File1",
+                        "createdAt": "29/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                    {
+                        "name": "File2",
+                        "createdAt": "30/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                ],
+            },
+            {
+                "name": "Schett",
+                "is_authenticated": False,
+                "files": [
+                    {
+                        "name": "File1",
+                        "createdAt": "29/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                    {
+                        "name": "File2",
+                        "createdAt": "30/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                    {
+                        "name": "File2",
+                        "createdAt": "30/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                    {
+                        "name": "File2",
+                        "createdAt": "30/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                    {
+                        "name": "File2",
+                        "createdAt": "30/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                    {
+                        "name": "File2",
+                        "createdAt": "30/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                    {
+                        "name": "File2",
+                        "createdAt": "30/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                    {
+                        "name": "File2",
+                        "createdAt": "30/07/2020",
+                        "viewUrl": "https://snek.at",
+                        "downloadUrl": "https://snek.at",
+                    },
+                ],
+            },
+        ],
+    }

--- a/tastic/views.py
+++ b/tastic/views.py
@@ -341,3 +341,6 @@ def reports(request):
             },
         ],
     }
+
+    # Render site
+    return render(request, "pages/reports.html", values)

--- a/templates/pages/reports.html
+++ b/templates/pages/reports.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>TASTIC - Engine</title>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.5.1/min/dropzone.min.css"
+    />
+  </head>
+  <body>
+    {% extends "base.html" %} {% block content %}
+    <div class="finder" style="padding-top: 1rem;">
+      <div class="row">
+        <div class="col-10">
+          <div class="input-group mb-3">
+            <input
+              type="text"
+              class="form-control"
+              placeholder="Filename or Username"
+              aria-label="Filename or Username"
+              aria-describedby="basic-addon2"
+            />
+            <div class="input-group-append">
+              <button class="btn btn-outline-secondary" type="button">
+                Search
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="col-2">
+          <div class="input-group mb-3">
+            <div class="input-group-prepend">
+              <button
+                class="btn btn-outline-secondary dropdown-toggle"
+                type="button"
+                data-toggle="dropdown"
+                aria-haspopup="true"
+                aria-expanded="false"
+              >
+                Sort: <b>{{ sortedBy }}</b>
+              </button>
+              <div class="dropdown-menu">
+                <a class="dropdown-item" href="#">Newest</a>
+                <a class="dropdown-item" href="#">Oldest</a>
+                <a class="dropdown-item" href="#">Smallest</a>
+                <a class="dropdown-item" href="#">Biggest</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="reports" style="padding-top: 1rem;">
+      <div class="row">
+        {% for user in users%}
+        <div class="col-6" style="padding-top: 1rem;">
+          <h4>{{ user.name }}</h4>
+          <div
+            class="list-group"
+            style="
+              max-height: 325px;
+              overflow-y: scroll;
+              -webkit-overflow-scrolling: touch;
+            "
+          >
+            {% for file in user.files %}
+            <li class="list-group-item" style="margin-top: 0.2rem;">
+              <div class="d-flex w-100 justify-content-between">
+                <div>
+                  <h5 class="mb-1">{{ file.name }}</h5>
+                  <small>Created on {{ file.createdAt }}</small>
+                </div>
+                <div>
+                  <button
+                    type="button"
+                    class="btn btn-outline-primary"
+                    onclick="window.open('{{ file.viewUrl }}', '_self')"
+                  >
+                    View
+                  </button>
+                  <button
+                    type="button"
+                    class="btn btn-outline-success"
+                    onclick="window.open('{{ file.downloadUrl }}')"
+                  >
+                    Download
+                  </button>
+                </div>
+              </div>
+            </li>
+            {% endfor %}
+          </div>
+          {% if user.is_authenticated %}
+          <button
+            type="button"
+            class="btn btn-success btn-lg btn-block"
+            style="margin-top: 0.2rem;"
+            data-toggle="modal"
+            data-target="#uploadModal"
+          >
+            Upload Status Report
+          </button>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    <!-- Modal -->
+    <div
+      class="modal fade"
+      id="uploadModal"
+      tabindex="-1"
+      role="dialog"
+      aria-labelledby="exampleModalLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="exampleModalLabel">Modal title</h5>
+            <button
+              type="button"
+              class="close"
+              data-dismiss="modal"
+              aria-label="Close"
+            >
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <form action="/file-upload" class="dropzone" id="upload">
+              <div class="fallback">
+                <input name="file" type="file" multiple />
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dropzone/5.5.1/min/dropzone.min.js"></script>
+    <script>
+      Dropzone.options.upload = {
+        paramName: "file", // The name that will be used to transfer the file
+        maxFilesize: 10, // MB
+        acceptedFiles: "application/pdf",
+        accept: function (file, done) {
+          done("File was uploaded!");
+        },
+      };
+    </script>
+    {% endblock %}
+  </body>
+</html>


### PR DESCRIPTION
**Checklist:**

 <!--- Make sure your PR is documented and tested before submission. Put an `x` in all the boxes that apply: -->
 - [x] Have you added an explanation of what your changes do and why you'd like them to be included?
 - [x] Have you updated or added documentation for the change?
 - [x] Have you tested your changes with successful results?


**Type of Changes:**

 <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)


**What is the current behavior? (link to any open issues here)**
- Currently there is no page template for displaying all status reports.


**What is the new behavior (if this is a feature change)?**
- Now there is an page template for displaying all status reports.


**Other information**:
- Ref: https://www.dropzonejs.com

Here a screenshot of the implemented changes.
![image](https://user-images.githubusercontent.com/55298934/89199106-62647d00-d5ae-11ea-9e6e-d1ca17d1092d.png)
